### PR TITLE
Initial compatibility for python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+language: python
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+    - python-setuptools
+    - python-nose
+    - python-pip
+    - python-dev
+    - make
+    - build-essential
+    - swig
+    - libgmp-dev
+    - autoconf
+    - libtool
+    - wget
+    - curl
+    - libboost-dev
+    - python3-all-dev
+
+python:
+  - 2.7
+  - 3.4
+  - 3.5
+
+install:
+  - "export PYTHON_INCL=`python${TRAVIS_PYTHON_VERSION}-config --includes`"
+  - if [ "${TRAVIS_PYTHON_VERSION}" == "3.5" ]; then export PYTHON_INCL=`/opt/python/3.5.0/bin/python3.5-config --includes`; fi
+  - "make -f Makefile_64bit PYTHON_INCL=${PYTHON_INCL}"
+
+script:
+  - "export PYTHONPATH=`pwd`"
+  - "echo ${PYTHONPATH}"
+  - "python examples/example1.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ python:
 
 install:
   - "export PYTHON_INCL=`python${TRAVIS_PYTHON_VERSION}-config --includes`"
+  # For some reason, Travis CI cannot find the commant python3.5-config.
+  # Therefore, we force the path here
   - if [ "${TRAVIS_PYTHON_VERSION}" == "3.5" ]; then export PYTHON_INCL=`/opt/python/3.5.0/bin/python3.5-config --includes`; fi
   - "make -f Makefile_64bit PYTHON_INCL=${PYTHON_INCL}"
 
@@ -34,3 +36,5 @@ script:
   - "export PYTHONPATH=`pwd`"
   - "echo ${PYTHONPATH}"
   - "python examples/example1.py"
+  - "python examples/example2.py"
+  - "python examples/example3.py"

--- a/Makefile_64bit
+++ b/Makefile_64bit
@@ -24,7 +24,7 @@ PYTHON_LOC  := /usr
 # Change the following to lib64 for 64-bit architectures
 LIB_DIR     := lib
 #PYTHON_LOC  := /usr
-PYTHON_VER  := python2.7
+PYTHON_VER  := python2.7 # Set this from command line for 2.6 or 3.4
 SWIG	    := /usr/bin/swig
 CCPLUS      := g++
 

--- a/ddnode.i
+++ b/ddnode.i
@@ -146,8 +146,8 @@ struct NodePair { };
 def __iter__(self):
   global iter_meth
   if iter_meth != 2:
-    print "Can only enumerate primes for a NodePair. Setting iter_meth == 2 and proceeding"
-    iter_meth == 2
+    print("Can only enumerate primes for a NodePair. Setting iter_meth == 2 and proceeding")
+    iter_meth = 2
   return ForeachPrimeIterator(self)
 __doc__="This is used to provide the functionality of prime enumeration in CUDD 2.4.0. Create the NodePair by passing the DdNodes for lower and upper to the constructor. Once that is done, you can iterate over the primes of the NodePair using the Python for statement. There is no need to do this if you are interested in the primes of a simple DdNode -- the package automatically creates the NodePair and destroys it in that case."
 

--- a/examples/example1.py
+++ b/examples/example1.py
@@ -1,22 +1,19 @@
 #!/usr/bin/python -i
-## Change above to point to your python. The -i option leaves you in interactive mode after the script has completed. Use ctrl-d to exit python.
+## Change above to point to your python.  The -i option leaves you in
+## interactive mode after the script has completed. Use ctrl-d to exit
+## python.
 
-## Import the pycudd module
-import pycudd
+## Import the repycudd module
+import repycudd
 
 ##
-## The next two steps are essential. PyCUDD has been set up so that the multitudinous
-## references to the DdManager are obviated. To achieve this, there is the notion of
-## a default manager. Though you may have as many DdManager objects as you want, only
-## one of them is active at any given point of time. All operations that require a
-## manager use the manager that last called the SetDefault method. 
-## 
-## NOTE: The DdManager constructor takes the same arguments as Cudd_Init. Refer ddmanager.i
-## to see the default values (which can be overriden when you call it)
-##
-mgr = pycudd.DdManager()
-mgr.SetDefault()
-
+## PyCUDD has the concept of global DdManager. In rePyCUDD, this is
+## not allowed, and the reference to the DdManager must always be
+## provided explicietly. This is the key difference between PyCUDD and
+## rePyCUDD. By having an explicit reference to the DdManager, it is
+## possible to manage multiple instances of the BDD package, deal with
+## multi-threading etc.
+mgr = repycudd.DdManager()
 
 ## This simple example finds the truths set of f = (f0 | f1) & f2 where
 ## f0 = (x4 & ~x3) | x2
@@ -32,14 +29,24 @@ x3 = mgr.IthVar(3)
 x4 = mgr.IthVar(4)
 
 ## Compute functions f0 through f2
-f0 = (x4 & ~x3) | x2
-f1 = (x3 & x1) | ~x0
-f2 = ~x0 + ~x3 + x4
+f0 = mgr.Or(mgr.And(x4,
+                    mgr.Not(x3)),
+            x2)
+
+f1 = mgr.Or(mgr.And(x3, x1),
+            mgr.Not(x0))
+
+f2 = mgr.Or(mgr.Or(mgr.Not(x0),
+                   mgr.Not(x3)),
+            x4)
+
+
 
 ## Compute function f
-f = (f0 | f1) & f2
+f = mgr.And(mgr.Or(f0, f1), f2)
 
 ## Print the truth set of f
-f.PrintMinterm()
+mgr.PrintMinterm(f)
 
-
+## To simplify the usage of the package, we recommend using pySMT to
+## build expressions. This allows a higher-level usage of the package.

--- a/examples/example2.py
+++ b/examples/example2.py
@@ -3,7 +3,7 @@
 
 # Import the module, create the manager
 import repycudd
-m = pycudd.DdManager()
+m = repycudd.DdManager()
 
 #
 # Create a random function as an example
@@ -13,10 +13,23 @@ m = pycudd.DdManager()
 a = m.IthVar(0)
 b = m.IthVar(1)
 c = m.IthVar(2)
+#  (~a & ~b & ((~c & ~m.IthVar(3)) |
+#              (c & m.IthVar(3)))) |
+#  (a & b & ((~c & m.IthVar(3)) | (c & ~m.IthVar(3))))
 
-rel = (~a & ~b & ((~c & ~m.IthVar(3)) | (c & m.IthVar(3)))) | (a & b & ((~c & m.IthVar(3)) | (c & ~m.IthVar(3))))
-rel |= (~a & b)
-rel |= (a & ~b)
+not_a = m.Not(a)
+not_b = m.Not(b)
+not_c = m.Not(c)
+
+rel_a = m.And(m.And(not_a, not_b),
+              m.Or(m.And(not_c, m.Not(m.IthVar(3))),
+                   m.And(c, m.IthVar(3))))
+rel_b = m.And(m.And(a, b),
+              m.Or(m.And(not_c, m.IthVar(3)),
+                   m.And(c, m.Not(m.IthVar(3)))))
+rel = m.Or(rel_a, rel_b)
+#rel = m.Or(rel, m.And(not_a, b))
+#rel = m.Or(rel, m.And(a, not_b))
 
 print("Going to iterate over the following function")
 m.PrintMinterm(rel)
@@ -29,22 +42,22 @@ m.PrintMinterm(rel)
 print("Testing iteration methods ...")
 # Over cubes
 print("Over cubes ...")
-pycudd.set_iter_meth(0)
-for cube in rel:
-    print(pycudd.cube_tuple_to_str(cube))
+repycudd.set_iter_meth(0)
+for cube in repycudd.ForeachCubeIterator(m, rel):
+    print(repycudd.cube_tuple_to_str(cube))
 
 # Over nodes
 print("Over nodes ...")
-pycudd.set_iter_meth(1)
-for node in rel:
+repycudd.set_iter_meth(1)
+for node in repycudd.ForeachNodeIterator(m, rel):
     print("***")
-    node.PrintMinterm()
+    m.PrintMinterm(node)
 
 # Over primes
-print("Over primes ...")
-pycudd.set_iter_meth(2)
-for prime in rel:
-    print(pycudd.cube_tuple_to_str(prime))
+# print("Over primes ...")
+# repycudd.set_iter_meth(2)
+# for prime in repycudd.ForeachPrimeIterator(m, repycudd.NodePair(rel, rel)):
+#     print(repycudd.cube_tuple_to_str(prime))
 
 #
 # One/two literal clause enumeration
@@ -53,11 +66,19 @@ for prime in rel:
 #
 # Simple POS expression (a + b)(!c + d)(!e + !f)(g + !h)i
 #
-h = (a | b) & (~c | m.IthVar(3)) & (~m.IthVar(4) | ~m.IthVar(5)) & (m.IthVar(6) | ~m.IthVar(7)) & m.IthVar(8)
+# h = (a | b) & (~c | m.IthVar(3)) & (~m.IthVar(4) | ~m.IthVar(5)) & (m.IthVar(6) | ~m.IthVar(7)) & m.IthVar(8)
+
+h = m.And(m.And(m.And(m.Or(a, b),
+                      m.Or(not_c, m.IthVar(3))),
+                m.And(m.Or(m.Not(m.IthVar(4)),
+                           m.Not(m.IthVar(5))),
+                      m.Or(m.IthVar(6), m.Not(m.IthVar(7))))),
+          m.IthVar(8))
+
 #
 # Create the DdTlcInfo object by calling
 #
-tlc = h.FindTwoLiteralClauses()
+tlc = m.FindTwoLiteralClauses(h)
 #
 # Read the clauses by calling ReadIthClause on the TlcInfo struct
 # This returns the clauses as 3-tuples -- the first member is 1 if a valid clause is returned,

--- a/examples/example2.py
+++ b/examples/example2.py
@@ -2,9 +2,8 @@
 # This example shows the 3 different ways to iterate over a DdNode
 
 # Import the module, create the manager
-import pycudd
+import repycudd
 m = pycudd.DdManager()
-m.SetDefault()
 
 #
 # Create a random function as an example
@@ -19,33 +18,33 @@ rel = (~a & ~b & ((~c & ~m.IthVar(3)) | (c & m.IthVar(3)))) | (a & b & ((~c & m.
 rel |= (~a & b)
 rel |= (a & ~b)
 
-print "Going to iterate over the following function"
-rel.PrintMinterm()
+print("Going to iterate over the following function")
+m.PrintMinterm(rel)
 
 #
 # The 3 iteration methods produce cubes, nodes and primes respectively
 # Note that since the package uses complement edges, the nodes may not be what
 # you expected!! Refer pyiter.i and ddnode.i for details on how this is done.
-# 
-print "Testing iteration methods ..."
+#
+print("Testing iteration methods ...")
 # Over cubes
-print "Over cubes ..."
+print("Over cubes ...")
 pycudd.set_iter_meth(0)
 for cube in rel:
-    print pycudd.cube_tuple_to_str(cube)
+    print(pycudd.cube_tuple_to_str(cube))
 
-# Over nodes     
-print "Over nodes ..."
+# Over nodes
+print("Over nodes ...")
 pycudd.set_iter_meth(1)
 for node in rel:
-    print "***"
+    print("***")
     node.PrintMinterm()
 
-# Over primes     
-print "Over primes ..."
+# Over primes
+print("Over primes ...")
 pycudd.set_iter_meth(2)
 for prime in rel:
-    print pycudd.cube_tuple_to_str(prime)
+    print(pycudd.cube_tuple_to_str(prime))
 
 #
 # One/two literal clause enumeration
@@ -54,7 +53,7 @@ for prime in rel:
 #
 # Simple POS expression (a + b)(!c + d)(!e + !f)(g + !h)i
 #
-h = (a | b) & (~c | m.IthVar(3)) & (~m.IthVar(4) | ~m.IthVar(5)) & (m.IthVar(6) | ~m.IthVar(7)) & m.IthVar(8) 
+h = (a | b) & (~c | m.IthVar(3)) & (~m.IthVar(4) | ~m.IthVar(5)) & (m.IthVar(6) | ~m.IthVar(7)) & m.IthVar(8)
 #
 # Create the DdTlcInfo object by calling
 #
@@ -68,6 +67,6 @@ tlc = h.FindTwoLiteralClauses()
 i=0
 cl = tlc.ReadIthClause(i)
 while cl[0] != 0:
-    print cl[1:]
+    print(cl[1:])
     i += 1
     cl = tlc.ReadIthClause(i)

--- a/examples/example3.py
+++ b/examples/example3.py
@@ -7,18 +7,21 @@
 ### NOTE: THIS IS STILL IN BETA
 ###
 ######################################
- 
-import pycudd
-m = pycudd.DdManager()
-m.SetDefault()
+
+import repycudd
+m = repycudd.DdManager()
 
 # Note how the DdArrays are created and initialised
-ips = pycudd.DdArray(2)
-ops=pycudd.DdArray(2)
+ips = repycudd.DdArray(m, 2)
+ops = repycudd.DdArray(m, 2)
 a = m.IthVar(0)
+not_a = m.Not(a)
 b = m.IthVar(1)
+not_b = m.Not(b)
 c = m.IthVar(2)
+not_c = m.Not(c)
 d = m.IthVar(3)
+not_d = m.Not(d)
 ips.Push(a)
 ips.Push(b)
 ops.Push(c)
@@ -27,26 +30,39 @@ ops.Push(d)
 #
 # Create a relation -- this maps 00 -> 00, 11; 11 -> 01, 10; 01 -> --; 10 -> --
 #
-rel = (~a & ~b & ((~c & ~d) | (c & d))) | (a & b & ((~c & d) | (c & ~d)))
-rel |= (~a & b)
-rel |= (a & ~b)
-print "The relation is"
-rel.PrintMinterm()
+#rel = (~a & ~b & ((~c & ~d) | (c & d))) |
+#      (a & b & ((~c & d) | (c & ~d)))
+rel = m.Or(m.And(m.And(not_a, not_b),
+                 m.Or(m.And(not_c, not_d),
+                      m.And(c, d))),
+           m.And(m.And(a, b), m.Or(m.And(not_c, d),
+                                   m.And(c, not_d))))
+rel = m.Or(rel, m.And(not_a, b))
+rel = m.Or(rel, m.And(a, not_b))
 
-# Create a BrelRelation_t object 
-bbr = pycudd.BrelRelation_t(rel,ips,ops)
-# Create a BREL Context -- more methods will be added to this class
-ct = pycudd.BrelContext_t()
-# Call the solver
-z = bbr.SolveRelation(ct)
+print("The relation is")
+m.PrintMinterm(rel)
 
-#
-# The solution is returned as a DdArray, which contains functions for the onset of
-# each minimised output. In our case, note how output 1 is reduced to always 0 --
-# thus, the call to PrintMinterm doesn't produce any output
-#
-print "Output 0 is"
-z[0].PrintMinterm()
+# Objects depending on the manager need to be free'd before the manager
+# Forcing this here
+del ips
+del ops
 
-print "Output 1 is"
-z[1].PrintMinterm()
+## This is currently not supported
+# # Create a BrelRelation_t object
+# bbr = repycudd.BrelRelation_t(rel,ips,ops)
+# # Create a BREL Context -- more methods will be added to this class
+# ct = repycudd.BrelContext_t()
+# # Call the solver
+# z = bbr.SolveRelation(ct)
+
+# #
+# # The solution is returned as a DdArray, which contains functions for the onset of
+# # each minimised output. In our case, note how output 1 is reduced to always 0 --
+# # thus, the call to PrintMinterm doesn't produce any output
+# #
+# print "Output 0 is"
+# z[0].PrintMinterm()
+
+# print "Output 1 is"
+# z[1].PrintMinterm()

--- a/pyiter.i
+++ b/pyiter.i
@@ -47,17 +47,18 @@ class ForeachCubeIterator:
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         if self.done: raise StopIteration
         to_ret = self.ret_val[1:]
         self.ret_val = self.node.NextCube(self.gen,self.mgr)
         if not self.ret_val[0]:
           self.done = 1
         return to_ret
+    next = __next__ # Python 2.7
 
 class ForeachNodeIterator:
     def __init__(self,mgr,Dd):
-        self.gen = DdGen(mrg,Dd,iter_meth)
+        self.gen = DdGen(mgr,Dd,iter_meth)
         self.node = Dd
         self.done = 0
         self.ret_val = Dd.FirstNode(self.gen)
@@ -66,13 +67,14 @@ class ForeachNodeIterator:
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         if self.done: raise StopIteration
         to_ret = self.ret_val[1]
         self.ret_val = self.node.NextNode(self.gen)
         if not self.ret_val[0]:
             self.done = 1
         return to_ret
+    next = __next__ # Python 2.7
 
 class ForeachPrimeIterator:
     def __init__(self,mgr,npair):
@@ -88,13 +90,14 @@ class ForeachPrimeIterator:
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         if self.done: raise StopIteration
         to_ret = self.ret_val[1:]
         self.ret_val = self.npair.NextPrime(self.gen)
         if not self.ret_val[0]:
             self.done = 1
         return to_ret
+    next = __next__ # Python 2.7
 
 def cube_tuple_to_str(cube_tup):
     res = ""

--- a/pyiter.i
+++ b/pyiter.i
@@ -32,7 +32,7 @@ def set_iter_meth(meth,verbose = False):
   global iter_meth
   methods = ["cubes", "nodes", "primes"]
   if verbose:
-      print "Setting iter method to iterate over ",methods[meth]
+     print("Setting iter method to iterate over %s", methods[meth])
   iter_meth = meth
 
 class ForeachCubeIterator:
@@ -52,7 +52,7 @@ class ForeachCubeIterator:
         to_ret = self.ret_val[1:]
         self.ret_val = self.node.NextCube(self.gen,self.mgr)
         if not self.ret_val[0]:
-	    self.done = 1
+          self.done = 1
         return to_ret
 
 class ForeachNodeIterator:
@@ -78,7 +78,7 @@ class ForeachPrimeIterator:
     def __init__(self,mgr,npair):
         global cudd_version
         if cudd_version < 0x020400:
-            print "CUDD versions < 2.4.0 do not support iteration over primes"
+            print("CUDD versions < 2.4.0 do not support iteration over primes")
             raise RuntimeError
         self.gen = DdGen(mgr,npair.LOWER(), iter_meth, npair.UPPER())
         self.npair = npair
@@ -92,7 +92,7 @@ class ForeachPrimeIterator:
         if self.done: raise StopIteration
         to_ret = self.ret_val[1:]
         self.ret_val = self.npair.NextPrime(self.gen)
-	if not self.ret_val[0]:
+        if not self.ret_val[0]:
             self.done = 1
         return to_ret
 


### PR DESCRIPTION
This introduces support for python 3.4 and 3.5. 

Travis CI is enabled by default, working on a few examples that better explain how to use rePyCUDD when compare to PyCUDD.
