### PR TITLE
Added function to dump dot format of a DdArray

### DIFF
--- a/ddmanager.i
+++ b/ddmanager.i
@@ -694,6 +694,18 @@ cerr << "Quitting manager" << endl;
     return retval;
   }
 
+  int DumpDotArray(DdArray *array, const char* fname) {
+    FILE *dfp = NULL;
+    int retval;
+
+    dfp = fopen(fname, "w");
+
+    retval = Cudd_DumpDot(self,1,array->vec,NULL,NULL,dfp);
+
+    fclose(dfp);
+    return retval;
+  }
+
   int DumpBlif(DdNode *this_node) {
 
     FILE *dfp = NULL;

--- a/ddmanager.i
+++ b/ddmanager.i
@@ -700,7 +700,7 @@ cerr << "Quitting manager" << endl;
 
     dfp = fopen(fname, "w");
 
-    retval = Cudd_DumpDot(self,1,array->vec,NULL,NULL,dfp);
+    retval = Cudd_DumpDot(self,array->sz,array->vec,NULL,NULL,dfp);
 
     fclose(dfp);
     return retval;


### PR DESCRIPTION
An example use of this feature is:
```python
import repycudd

mgr = repycudd.DdManager()
v = mgr.NewVar()
vec = mgr.Vector(v1)

mgr.DumpDotArray(vec, '/tmp/testfile.dot')
```